### PR TITLE
cleanings

### DIFF
--- a/_restxq/webapp.xqm
+++ b/_restxq/webapp.xqm
@@ -57,28 +57,12 @@ declare default function namespace 'synopsx.webapp' ;
 declare 
   %restxq:path("")
 function index() {
-  <rest:response>
-    <http:response status="303" message="See Other">
-      <http:header name="location" value="/home"/>
-    </http:response>
-  </rest:response>
-};
-
-(:~
- : this resource function is the default home
- : @return a home based on the default project in 'config.xml'
- : @todo move project test to lib/ ?
- :)
-declare 
-  %restxq:path("/home")
-  %restxq:produces('text/html')
-  %output:method("html")
-  %output:html-version("5.0")
-function home() {
    web:redirect(if(db:exists("synopsx"))
               then synopsx.models.synopsx:getDefaultProject() || '/' (: rediriger vers le projet par défault :)
               else '/synopsx/install')
 };
+
+
 
 
 (:~

--- a/files/xsl/tei2html.xsl
+++ b/files/xsl/tei2html.xsl
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
 	xpath-default-namespace="http://www.tei-c.org/ns/1.0"
 	xmlns="http://www.w3.org/1999/xhtml" xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="xs">
 	<xsl:output method="xml" encoding="UTF-8" indent="yes" omit-xml-declaration="yes"/>
-	<xsl:strip-space elements="*"/>
+	<xsl:preserve-space elements="*"/>
 	<!--
 	     group
 	     text

--- a/models/synopsx.xqm
+++ b/models/synopsx.xqm
@@ -122,7 +122,7 @@ declare function getLayoutPath($queryParams as map(*), $template as xs:string?) 
  : @return a path 
  :)
 declare function getXsltPath($queryParams as map(*), $xsl as xs:string?) as xs:string { 
-  let $path :=  fn:trace($G:WEBAPP || 'synopsx/files/' || map:get($queryParams, 'project') || '/xsl/' || $xsl)
+  let $path :=  $G:WEBAPP || 'static/' || map:get($queryParams, 'project') || '/xsl/' || $xsl
   return 
     if (file:exists($path)) 
     then $path


### PR DESCRIPTION
- change strip spaces to preserve spaces in tei2html.xsl ; 
- default tei functions now return nodes sequences instead of joined strings (getTitles, getAbstract, etc.) in order not to loose inner tagging.
- clean some useless module namespace declarations
- remove the default /home restxq function in order not to duplicate with default project home function
