### PR TITLE
use the fetch module

### DIFF
--- a/_restxq/files.xqm
+++ b/_restxq/files.xqm
@@ -52,5 +52,5 @@ function synopsx.files:file($file as xs:string) as item()+ {
 declare function synopsx.files:mime-type(
   $name  as xs:string
 ) as xs:string {
-  Q{java:org.basex.io.MimeTypes}get($name)
+  fetch:content-type($name)
 };


### PR DESCRIPTION
Use of the fetch module instead of a java class. An error was occuring
with the previous version since a change in BaseX or Java.