### PR TITLE
Rétabli login / interdire nom de projet déjà existant

### DIFF
--- a/_restxq/synopsx.xqm
+++ b/_restxq/synopsx.xqm
@@ -26,6 +26,7 @@ module namespace synopsx.synopsx = 'synopsx.synopsx' ;
  :)
 
 import module namespace rest = "http://exquery.org/ns/restxq";
+import module namespace Session = 'http://basex.org/modules/session';
 import module namespace G = 'synopsx.globals' at '../globals.xqm' ;
 import module namespace synopsx.models.tei = 'synopsx.models.tei' at '../models/tei.xqm' ;
 import module namespace synopsx.models.synopsx = 'synopsx.models.synopsx' at '../models/synopsx.xqm' ;
@@ -89,6 +90,7 @@ function home(){
 
 declare 
   %rest:GET
+  %perm:allow("admin")
   %rest:path('/synopsx/config')
   %output:method('html')
   %output:html-version('5.0')
@@ -111,6 +113,7 @@ function config() as element() {
 
 declare 
   %rest:POST
+  %perm:allow('admin')
   %rest:path('/synopsx/config')
   %output:method('html')
   %rest:query-param("project",  "{$project}")
@@ -118,17 +121,18 @@ declare
 function config($project) {
     db:create-backup('synopsx'),
     delete node db:open('synopsx', 'config.xml')//@default, (: supprimer tout attribut défault préexistant :)
-    insert node (attribute { 'default' } { 'true' }) into db:open('synopsx', 'config.xml')//project[resourceName/text()=$project],
+    insert node (attribute { 'default' } { 'true' }) into db:open('synopsx', 'config.xml')//project[resourceName/text()=$project][1],
     update:output(web:redirect("/synopsx/config"))  
 };
 
 
 declare 
   %rest:GET
+   %perm:allow('admin')
   %rest:path('/synopsx/create-project')
   %output:method('html')
   %output:html-version('5.0')
-function create_project() as element(html) {
+function create_project() as element() {
   let $queryParams := map {
     
     }
@@ -141,17 +145,102 @@ function create_project() as element(html) {
 
 declare 
   %rest:POST
+   %perm:allow('admin')
   %rest:path('/synopsx/create-project')
   %output:method('html')
   %rest:query-param("project",  "{$project}")
   %updating
 function create_project($project) {
-  db:create($project, (), (), map { 'chop': fn:true(), 'textindex': fn:true(),'attrindex': fn:true() }),
-  insert node 
-      <project> 
-        <resourceName>{$project}</resourceName>
-        <dbName>{$project}</dbName>
-      </project>      
-  into db:open('synopsx', 'config.xml')//projects,
-  update:output(web:redirect("/synopsx/config"))
+  if(db:open('synopsx', 'config.xml')//project[resourceName/text()=$project]) then 
+  update:output(web:redirect("/synopsx/config/unavailable"))
+  else
+      (db:create($project, (), (), map { 'chop': fn:true(), 'textindex': fn:true(),'attrindex': fn:true() }),
+      insert node 
+          <project> 
+            <resourceName>{$project}</resourceName>
+            <dbName>{$project}</dbName>
+          </project>      
+      into db:open('synopsx', 'config.xml')//projects,
+      update:output(web:redirect("/synopsx/config"))
+      )
+};
+
+
+declare 
+  %rest:GET
+  %perm:allow("admin")
+  %rest:path('/synopsx/config/{$checkName}')
+  %output:method('html')
+  %output:html-version('5.0')
+function create-project($checkName) as element() {
+  let $queryParams := map {
+    'project' : $synopsx.synopsx:project,
+    'dbName' :  $synopsx.synopsx:db,
+    'model' : 'synopsx' ,
+    'function' : 'getProjectsList',
+    'checkName' : $checkName
+    }
+  let $outputParams :=map {
+    'lang' : 'fr',
+    'layout' : 'config.xhtml',
+    'pattern' : 'inc_configItem.xhtml'
+    (: specify an xslt mode and other kind of output options :)
+    }
+ return synopsx.models.synopsx:htmlDisplay($queryParams, $outputParams)
+
+};
+
+(:~ Login page (visible to everyone). :)
+declare
+  %rest:path("/synopsx/login")
+  %output:method("html")
+function login() {
+    fn:doc($G:HOME || 'templates/login.xhtml')
+};
+
+declare
+  %rest:path("/synopsx/login-check")
+  %rest:query-param("name", "{$name}")
+  %rest:query-param("pass", "{$pass}")
+  function login($name, $pass) {
+  if (fn:empty($name)) then  web:redirect("/synopsx/login")
+  else
+  try {
+    user:check($name, $pass),
+    Session:set('id', $name),
+    web:redirect("/synopsx")
+  } catch user:* {
+    web:redirect("/synopsx/login")
+  }
+};
+
+declare
+  %rest:path("/synopsx/logout")
+function logout() {
+  Session:delete('id'),
+  web:redirect("/synopsx")
+};
+
+declare %perm:check('/synopsx/install', '{$perm}') function check-install($perm) {
+  if (fn:empty(Session:get('id'))) then  web:redirect("/synopsx/login")
+  else
+  let $user := Session:get('id')
+  where fn:not(user:list-details($user)/@permission = $perm?allow)
+  return web:redirect("/synopsx/login")
+};
+
+declare %perm:check('/synopsx/config', '{$perm}') function check-config($perm) {
+   if (fn:empty(Session:get('id'))) then  web:redirect("/synopsx/login")
+  else
+  let $user := Session:get('id')
+  where fn:not(user:list-details($user)/@permission = $perm?allow)
+  return web:redirect("/synopsx/login")
+};
+
+declare %perm:check('/synopsx/create-project', '{$perm}') function check-create-project($perm) {
+  if (fn:empty(Session:get('id'))) then  web:redirect("/synopsx/login")
+  else
+  let $user := Session:get('id')
+  where fn:not(user:list-details($user)/@permission = $perm?allow)
+  return web:redirect("/synopsx/login")
 };

--- a/_restxq/synopsx.xqm
+++ b/_restxq/synopsx.xqm
@@ -92,7 +92,7 @@ declare
   %rest:path('/synopsx/config')
   %output:method('html')
   %output:html-version('5.0')
-function config() as element(html) {
+function config() as element() {
   let $queryParams := map {
     'project' : $synopsx.synopsx:project,
     'dbName' :  $synopsx.synopsx:db,

--- a/mappings/htmlWrapping.xqm
+++ b/mappings/htmlWrapping.xqm
@@ -57,8 +57,8 @@ declare default function namespace 'synopsx.mappings.htmlWrapping' ;
  :
  :)
 declare function wrapper($queryParams as map(*), $data as map(*), $outputParams as map(*)) as node()* {
-  let $meta := map:get($data, 'meta')
-  let $layout := synopsx.models.synopsx:getLayoutPath($queryParams, map:get($outputParams, 'layout'))
+  let $meta := $data('meta')
+  let $layout := synopsx.models.synopsx:getLayoutPath($queryParams, $outputParams('layout'))
   let $wrap := fetch:xml($layout)
   let $regex := '\{(.*?)\}'
   return

--- a/models/synopsx.xqm
+++ b/models/synopsx.xqm
@@ -42,9 +42,9 @@ declare default function namespace "synopsx.models.synopsx";
  :)
 declare function getProjectsList($queryParams as map(*)) as map(*) {
   let $projects := db:open('synopsx', 'config.xml')//project
+  let $count := fn:string(fn:count($projects))
   let $meta := map{
-    'title' : 'Liste des projets',
-    'count' : fn:string(fn:count($projects)),
+    'title' : $count || 'configured projects',
     'defaultProject' : getDefaultProject()
     }
   let $content := for $project in $projects return 
@@ -56,7 +56,7 @@ declare function getProjectsList($queryParams as map(*)) as map(*) {
   };
 
 declare function getSynopsxStatus($project) as map(*) {
-  let $isDefault := if (fn:exists($project/@default) and $project/@default=fn:true())
+  let $isDefault := if (fn:exists($project/@default) and $project/@default='true')
                     then "checked"
                     else ""
   return map {'project':fn:string($project/resourceName/text()), 'isDefault':$isDefault}

--- a/models/synopsx.xqm
+++ b/models/synopsx.xqm
@@ -43,9 +43,11 @@ declare default function namespace "synopsx.models.synopsx";
 declare function getProjectsList($queryParams as map(*)) as map(*) {
   let $projects := db:open('synopsx', 'config.xml')//project
   let $count := fn:string(fn:count($projects))
+  let $checkName := if ($queryParams('checkName') = 'unavailable') then 'A project with this name already exists' else  ''
   let $meta := map{
-    'title' : $count || 'configured projects',
-    'defaultProject' : getDefaultProject()
+    'title' : $count || ' configured projects',
+    'defaultProject' : getDefaultProject(),
+    'checkName' : $checkName
     }
   let $content := for $project in $projects return 
     getSynopsxStatus($project)

--- a/models/tei.xqm
+++ b/models/tei.xqm
@@ -97,7 +97,8 @@ declare function getCorpusMap($item as item()) as map(*) {
    let $meta := map{
     'title' : if (fn:count($texts) = 1) then getTitles($texts[1]) else fn:count($texts) || ' TEI texts',
     'msg' :  if ($missingIds = 0 ) then '' else 'WARNING : ' || $missingIds || ' TEI elements require(s) the @xml:id attribute (generating errors in the SynopsX webapp !)',
-    'description' :   if (fn:count($texts) = 1) then getTitles($texts[1]) else fn:count($texts) || ' TEI texts'
+    'description' :   if (fn:count($texts) = 1) then getTitles($texts[1]) else fn:count($texts) || ' TEI texts',
+    'project' : $queryParams('project')
     }
   let $content := for $text in $texts return getTEIMap($text)
   return  map{

--- a/templates/config.xhtml
+++ b/templates/config.xhtml
@@ -33,9 +33,7 @@
       <p>Default project : <span>{defaultProject}</span></p>
       <p>Change default project</p>
       <form action="/synopsx/config" method="POST" class="form-inline">
-        <select name="project">
-        {content}
-      </select>
+        <select name="project">{content}</select>
         <input type="submit" value="OK"  style="display:inline;"/>
       </form>  
 

--- a/templates/config.xhtml
+++ b/templates/config.xhtml
@@ -32,6 +32,7 @@
   <section>
       <p>Default project : <span>{defaultProject}</span></p>
       <p>Change default project</p>
+      <p><span style="color:red;">{checkName}</span></p>
       <form action="/synopsx/config" method="POST" class="form-inline">
         <select name="project">{content}</select>
         <input type="submit" value="OK"  style="display:inline;"/>

--- a/templates/default.xhtml
+++ b/templates/default.xhtml
@@ -28,9 +28,7 @@
  <h3>{title}</h3>
  <p>{msg}</p>
  <hr/>
-  <section>
-      {content}  
-  </section>  
+  <section>{content}</section>  
 </div>
 </div>
 

--- a/templates/home.xhtml
+++ b/templates/home.xhtml
@@ -28,9 +28,7 @@
  <h3>{title}</h3>
   <p style="color:red;">{msg}</p>
  <hr/>
-  <section>
-      {content}  
-  </section>  
+  <section>{content}</section>  
 </div>
 </div>
 

--- a/templates/inc_configItem.xhtml
+++ b/templates/inc_configItem.xhtml
@@ -2,4 +2,4 @@
   TODO : revenir à un système d'attributs @data, par exemple @data-content et @data-attribute pour une écriture plus propre
   réécrire la fontion synopsx.mappings.htmlWrapping:simplePattern en fonction de ce changement
  -->
-<option value="{project}">{project}</option>
+<option checked="{isDefault}" value="{project}">{project}</option>

--- a/templates/synopsx.xhtml
+++ b/templates/synopsx.xhtml
@@ -26,9 +26,7 @@
 <div class="row">
 <hr/><hr/><hr/>
 
-  <section>
-      {content}  
-  </section>  
+  <section>{content}</section>  
 </div>
 </div>
 


### PR DESCRIPTION
- rétabli la correction des erreurs d'affichage (retours ligne dans les templates = pages vides)

- rétabli le login pour accéder aux pages de config et d'admin ; @todo :  passage de session entre dba et synopsx

- créé un test pour interdire la création d'un projet si un projet du même nom existe déjà

